### PR TITLE
Fix logs

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -102,7 +102,7 @@ func registerHandlerForResolver(pattern string, db *bolt.DB, address string, met
 			if err != nil {
 				metrics <- ms.NewMetric("resolver-error", nil, nil, time.Now(), ms.Counter)
 				raven.CaptureError(err, map[string]string{"unit": "dns"})
-				log.Fatal("[resolver] ", err)
+				log.Errorf("Resolver: %s for %s", err, qname, dns.TypeToString[qtype])
 				m.SetRcode(r, dns.RcodeServerFailure)
 			} else {
 				for _, answer := range answers {
@@ -114,7 +114,7 @@ func registerHandlerForResolver(pattern string, db *bolt.DB, address string, met
 
 		w.WriteMsg(m)
 		answersfmt := u.FormatAnswers(m.Answer)
-		log.Infof("[DNS] Answered to %s::%s request: %s with the type %s - found %d answer(s): \n%s",
+		log.Infof("[DNS] Answered to %s::%s request: %s with the type %s - found %d answer(s): \n %s",
 			remoteAddr.Network(), remoteAddr.String(), qname, dns.TypeToString[qtype], len(m.Answer), answersfmt)
 	})
 }
@@ -258,7 +258,7 @@ func findRecordsAndSetAsAnswersInMessage(qname string, qtype uint16, db *bolt.DB
 	if err != nil {
 		metrics <- ms.NewMetric("err-queries", nil, nil, time.Now(), ms.Counter)
 		raven.CaptureError(err, map[string]string{"unit": "dns", "action": "find records"})
-		log.Fatal("[dns]: ", err)
+		log.Errorf("[dns]: %s for %s", err, qname, dns.TypeToString[qtype])
 	}
 }
 

--- a/dns.go
+++ b/dns.go
@@ -102,7 +102,7 @@ func registerHandlerForResolver(pattern string, db *bolt.DB, address string, met
 			if err != nil {
 				metrics <- ms.NewMetric("resolver-error", nil, nil, time.Now(), ms.Counter)
 				raven.CaptureError(err, map[string]string{"unit": "dns"})
-				log.Errorf("Resolver: %s for %s", err, qname, dns.TypeToString[qtype])
+				log.Errorf("Resolver: %s for %s %s", err, qname, dns.TypeToString[qtype])
 				m.SetRcode(r, dns.RcodeServerFailure)
 			} else {
 				for _, answer := range answers {
@@ -258,7 +258,7 @@ func findRecordsAndSetAsAnswersInMessage(qname string, qtype uint16, db *bolt.DB
 	if err != nil {
 		metrics <- ms.NewMetric("err-queries", nil, nil, time.Now(), ms.Counter)
 		raven.CaptureError(err, map[string]string{"unit": "dns", "action": "find records"})
-		log.Errorf("[dns]: %s for %s", err, qname, dns.TypeToString[qtype])
+		log.Errorf("[dns]: %s for %s %s", err, qname, dns.TypeToString[qtype])
 	}
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -65,5 +65,5 @@ func FormatAnswers(answers []dns.RR) string {
 // The default String method put \t between each elements. This method replace this all \t by a whitespace
 func FormatAnswer(answer dns.RR) string {
 	h := answer.String()
-	return strings.ReplaceAll(h, "\t", " ")
+	return strings.Replace(h, "\t", " ", -1) // ReplaceAll is in tip, but not in latest release of go 1.11.1
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -64,6 +64,6 @@ func FormatAnswers(answers []dns.RR) string {
 // Name. TTL Class Type
 // The default String method put \t between each elements. This method replace this all \t by a whitespace
 func FormatAnswer(answer dns.RR) string {
-	h := answer.Header().String()
+	h := answer.String()
 	return strings.ReplaceAll(h, "\t", " ")
 }


### PR DESCRIPTION
This PR update logs:
- Remove all Log.Fatal in dns.go to avoid a deny of the service
- Print `content` in dns response log.