### PR TITLE
Change record.Type from string to uint16 to be more coherent with our dns lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,19 @@ module stream-dns
 go 1.12
 
 require (
-	github.com/Shopify/sarama v1.23.0 // indirect
-	github.com/bsm/sarama-cluster v2.1.15+incompatible // indirect
+	github.com/Shopify/sarama v1.23.0
+	github.com/bsm/sarama-cluster v2.1.15+incompatible
+	github.com/cactus/go-statsd-client/statsd v0.0.0-20190501063751-9a7692639588
 	github.com/certifi/gocertifi v0.0.0-20190506164543-d2eda7129713 // indirect
-	github.com/getsentry/raven-go v0.2.0 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/getsentry/raven-go v0.2.0
 	github.com/miekg/dns v1.1.15
+	github.com/miton18/go-warp10 v0.0.0-20190522085847-5bfc5e407caf
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
-	github.com/sirupsen/logrus v1.4.2 // indirect
-	github.com/spf13/viper v1.4.0 // indirect
+	github.com/sirupsen/logrus v1.4.2
+	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
-	go.etcd.io/bbolt v1.3.3 // indirect
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
+	go.etcd.io/bbolt v1.3.3
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bsm/sarama-cluster v2.1.15+incompatible h1:RkV6WiNRnqEEbp81druK8zYhmnIgdOjqSVi0+9Cnl2A=
 github.com/bsm/sarama-cluster v2.1.15+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
+github.com/cactus/go-statsd-client/statsd v0.0.0-20190501063751-9a7692639588 h1:6yVhh6P5OsW6HutPt7z2ggDgZczgUtSl2kGRe+DslPU=
+github.com/cactus/go-statsd-client/statsd v0.0.0-20190501063751-9a7692639588/go.mod h1:3/sdo8I67TaOslRGJ6FqQC/ynu+wg7H6IE4WYtr51hk=
 github.com/certifi/gocertifi v0.0.0-20190506164543-d2eda7129713 h1:UNOqI3EKhvbqV8f1Vm3NIwkrhq388sGCeAH2Op7w0rc=
 github.com/certifi/gocertifi v0.0.0-20190506164543-d2eda7129713/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -27,6 +29,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/eapache/go-resiliency v1.1.0 h1:1NtRmCAqadE2FN4ZcN6g90TP3uk8cg9rn9eNK2197aU=
@@ -83,6 +86,8 @@ github.com/miekg/dns v1.1.15 h1:CSSIDtllwGLMoA6zjdKnaE6Tx6eVUxQ29LUgGetiDCI=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/miton18/go-warp10 v0.0.0-20190522085847-5bfc5e407caf h1:jS6mMnkUcgMD/MsdbHz6GXvZmM4IPe8Da285o7TmzyQ=
+github.com/miton18/go-warp10 v0.0.0-20190522085847-5bfc5e407caf/go.mod h1:X3SyVTsihIuF7jrMceSGI4nTkk/wxztMuZCX+9pK8oQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/http_administrator_test.go
+++ b/http_administrator_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/suite"
 	bolt "go.etcd.io/bbolt"
 )
@@ -114,10 +115,10 @@ func (suite *HttpAdministratorSuite) TestShouldBeSignedAndGetJWTIfSendCorrectCre
 
 func (suite *HttpAdministratorSuite) TestSearchRecords() {
 	var records = [][]Record{
-		[]Record{Record{"www.example.com.", "A", "1.1.1.1", 3600, 0}},
-		[]Record{Record{"test.foo.bar.io.", "A", "2.2.2.2", 1200, 0}},
-		[]Record{Record{"test.foo.io.", "A", "4.4.4.4", 3600, 0}},
-		[]Record{Record{"test.bar.io.", "A", "4.4.4.4", 3600, 0}},
+		[]Record{Record{"www.example.com.", dns.TypeA, "1.1.1.1", 3600, 0}},
+		[]Record{Record{"test.foo.bar.io.", dns.TypeA, "2.2.2.2", 1200, 0}},
+		[]Record{Record{"test.foo.io.", dns.TypeA, "4.4.4.4", 3600, 0}},
+		[]Record{Record{"test.bar.io.", dns.TypeA, "4.4.4.4", 3600, 0}},
 	}
 
 	seedDBwithRecords(suite.DB, records)
@@ -153,10 +154,10 @@ func (suite *HttpAdministratorSuite) TestSearchRecords() {
 
 func (suite *HttpAdministratorSuite) TestSearchRecordsAndShouldFindNothing() {
 	var records = [][]Record{
-		[]Record{Record{"www.example.com.", "A", "1.1.1.1", 3600, 0}},
-		[]Record{Record{"test.foo.bar.io.", "A", "2.2.2.2", 1200, 0}},
-		[]Record{Record{"test.foo.io.", "A", "4.4.4.4", 3600, 0}},
-		[]Record{Record{"test.bar.io.", "A", "4.4.4.4", 3600, 0}},
+		[]Record{Record{"www.example.com.", dns.TypeA, "1.1.1.1", 3600, 0}},
+		[]Record{Record{"test.foo.bar.io.", dns.TypeA, "2.2.2.2", 1200, 0}},
+		[]Record{Record{"test.foo.io.", dns.TypeA, "4.4.4.4", 3600, 0}},
+		[]Record{Record{"test.bar.io.", dns.TypeA, "4.4.4.4", 3600, 0}},
 	}
 
 	seedDBwithRecords(suite.DB, records)

--- a/record.go
+++ b/record.go
@@ -8,7 +8,7 @@ import (
 
 type Record struct {
 	Name     string
-	Type     string
+	Type     uint16
 	Content  string
 	Ttl      int
 	Priority int
@@ -32,9 +32,9 @@ func PTR(rr string) *dns.PTR { r, _ := dns.NewRR(rr); return r.(*dns.PTR) }
 
 func recordToString(record Record) string {
 	if record.Priority > 0 {
-		return fmt.Sprintf("%s %d IN %s %d %s", record.Name, record.Ttl, record.Type, record.Priority, record.Content)
+		return fmt.Sprintf("%s %d IN %s %d %s", record.Name, record.Ttl, dns.TypeToString[record.Type], record.Priority, record.Content)
 	} else {
-		return fmt.Sprintf("%s %d IN %s %s", record.Name, record.Ttl, record.Type, record.Content)
+		return fmt.Sprintf("%s %d IN %s %s", record.Name, record.Ttl, dns.TypeToString[record.Type], record.Content)
 	}
 }
 
@@ -51,10 +51,9 @@ func recordSOAToString(record Record) string {
 
 func RecordToAnswer(record Record) dns.RR {
 	var rr dns.RR
-	rtype := dns.StringToType[record.Type]
 	recordstr := recordToString(record)
 
-	switch rtype {
+	switch record.Type {
 	case dns.TypeA:
 		rr = A(recordstr)
 	case dns.TypeAAAA:

--- a/resolver.go
+++ b/resolver.go
@@ -145,7 +145,7 @@ func AnswerToRecord(name string, answer dns.RR) Record {
 	rrtype := answer.Header().Rrtype
 	record := Record{
 		Name: answer.Header().Name,
-		Type: dns.TypeToString[rrtype],
+		Type: rrtype,
 		Ttl:  int(answer.Header().Ttl),
 	}
 


### PR DESCRIPTION
The DNS lib that we use define the `qtype` with a `uint16`: https://github.com/miekg/dns/blob/master/types.go#L23. For now, the type use in the `Type Record` is `String` where that need to cast sometime this in `uint16` in some literals and predicates. To avoid this and to be more consistent with this lib, we should use `uint16` has type for the Qtype in Record instead of String.