### PR TITLE
Add an instance_id in the configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following environment variables can be set:
 
 | Variable                   | Type           | Description                                                                                     |
 |----------------------------|----------------|-------------------------------------------------------------------------------------------------|
+| DNS_INSTANCE_ID            | string         | Unique Identifier of this stream-dns instance                                                   |
 | DNS_ADDRESS                | string         | Address for the DNS server e.g: ":8053"                                                         |
 | DNS_TCP                    | bool           | Accept TCP DNS connection                                                                       |
 | DNS_UDP                    | bool           | Accept UDP DNS connection                                                                       |

--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	PathDB              string
 	sentryDSN           string
 	DisallowCNAMEonAPEX bool
+	InstanceId          string
 }
 
 type StatsdConfig struct {

--- a/main.go
+++ b/main.go
@@ -74,6 +74,8 @@ func main() {
 		viper.GetString("instance_id"),
 	}
 
+	log.WithField("id", config.InstanceId).Info("Starting stream-dns")
+
 	// Sentry
 	raven.SetDSN(config.sentryDSN)
 

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 		viper.GetString("pathdb"),
 		viper.GetString("sentry_dsn"),
 		viper.GetBool("disallow_cname_on_apex"),
+		viper.GetString("instance_id"),
 	}
 
 	// Sentry
@@ -92,7 +93,7 @@ func main() {
 
 	// Setup Statsd is config exist
 	if config.Statsd.Address != "" {
-		statsdOutput := output.NewStatsdOutput(config.Statsd.Address, config.Statsd.Prefix)
+		statsdOutput := output.NewStatsdOutput(config.Statsd.Address, config.Statsd.Prefix, "id", config.InstanceId)
 		agent.AddOutput(statsdOutput)
 	}
 


### PR DESCRIPTION
The instance_id will be used in the metric tags for `statsd`.
An enhancement could be to prefix all the logs with this ID. For now, we only print the ID in the first log.
This ID may be used in many other futur features.