### PR TITLE
Generate a random instance_id when the DNS_INSTANCE_ID config field is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following environment variables can be set:
 
 | Variable                   | Type           | Description                                                                                                                                             |
 |----------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DNS_INSTANCE_ID            | string         | Unique Identifier of this stream-dns instance                                                                                                           |
+| DNS_INSTANCE_ID            | string         | (optional) Unique Identifier of this stream-dns instance                                                                                                           |
 | DNS_ADDRESS                | string         | Address for the DNS server e.g: ":8053"                                                                                                                 |
 | DNS_TCP                    | bool           | Accept TCP DNS connection                                                                                                                               |
 | DNS_UDP                    | bool           | Accept UDP DNS connection                                                                                                                               |

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/getsentry/raven-go"
+	"github.com/google/uuid"
 	dns "github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -105,6 +106,11 @@ func main() {
 		viper.GetBool("disallow_cname_on_apex"),
 		viper.GetString("instance_id"),
 		viper.GetString("local_records"),
+	}
+
+	if config.InstanceId == "" {
+		config.InstanceId = uuid.New().String()
+		log.Warn("The configuration DNS_INSTANCE_ID was not set, we generate one by default.")
 	}
 
 	log.WithField("id", config.InstanceId).Info("Starting stream-dns")


### PR DESCRIPTION
This PR adds a feature which generates a random UUID for the configuration field: `DNS_INSTANCE_ID`. This avoids caring about this configuration field when the instance is ephemeral.

NOTE: We use the `github.com/google/uuid` implementation.