### PR TITLE
fix: move docker build to go module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM golang:stretch
 
-ADD . /go/src/stream-dns
+ENV GO111MODULE on
 
-RUN go get -v stream-dns
+WORKDIR /go/src/stream-dns
+
+COPY go.sum ./go.sum
+COPY go.mod ./go.mod
+
+RUN go mod download
+
+ADD . .
 
 RUN CGO_ENABLED=0 GOOS=linux go install -a -installsuffix cgo stream-dns
 


### PR DESCRIPTION
When I try to build the docker image I run into `CommitInterval` not being found at build time.

That's because:
1. commit [72a629d7d1ac130c1f1221e66396e0b54dfeef3f](https://github.com/Shopify/sarama/commit/72a629d7d1ac130c1f1221e66396e0b54dfeef3f#diff-b4bda758a2aef091432646c354b4dc59) on sarama renamed `Offsets.CommitInterval` to `AutoCommit.Interval`
2. Samara Cluster is [deprecated](https://github.com/bsm/sarama-cluster)
3. `go get` will take the latest version from samara

Moved to go modules instead

I took this opportunity to also place the dependency download into its own image layer to make it easier for my connection :)
